### PR TITLE
update Tableau Server version to 10.4

### DIFF
--- a/templates/tableau-server-single-server.template
+++ b/templates/tableau-server-single-server.template
@@ -795,7 +795,7 @@
                                 "waitAfterCompletion": "0"
                             },
                             "08-publish-redshift-datasource": {
-                                "cwd": "C:\\TableauServer\\10.3\\bin",
+                                "cwd": "C:\\TableauServer\\10.4\\bin",
                                 "command": {
                                     "Fn::Join": [
                                         "",
@@ -829,7 +829,7 @@
                                 "waitAfterCompletion": "0"
                             },
                             "09-publish-postgres-datasource": {
-                                "cwd": "C:\\TableauServer\\10.3\\bin",
+                                "cwd": "C:\\TableauServer\\10.4\\bin",
                                 "command": {
                                     "Fn::Join": [
                                         "",
@@ -863,7 +863,7 @@
                                 "waitAfterCompletion": "0"
                             },
                             "10-publish-sample-dashboard": {
-                                "cwd": "C:\\TableauServer\\10.3\\bin",
+                                "cwd": "C:\\TableauServer\\10.4\\bin",
                                 "command": {
                                     "Fn::Join": [
                                         "",


### PR DESCRIPTION
@santiagocardenas - we noticed that Tableau rolled the published TS version to 10.4, this PR keeps the Quick Start in sync and functioning properly.

Please review and merge.